### PR TITLE
Add :setcookie, grabbing cookie from file

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,66 +192,20 @@ func main() {
 		return
 	}
 
-	var prog string
-
-	// 2020 day 3
-	prog = `
-;=input boolgrid "#."
-;iterate (offset [3,1]) [0,0] | takeWhile (inbounds input) | map (input._) | sum
-`
-
-	// 2020 day 10
-	prog = `
-=input ints
-sort | deltas | histogram |: (_.1 + 1) * (_.3 + 1)
-`
-
-	// 2015 day 3
-	prog = `
-=input chars | dirs "^v<>"
-=a actor [0,0]
-=a move a
-
-`
-
-	// 2016 day 2
-	prog = `
-=input lines | map (dirs "UDLR")
-=m maze (==" ") [
-	"123",
-	"456",
-	"789",
-]
-=a actor (center m) m
-map (move a | .tile)
-
-=m maze (==" ") [
-	"  1  ",
-	" 234 ",
-	"56789",
-	" ABC ",
-	"  D  ",
-]
-=a actor (center m) m
-map (move a | .tile)
-`
-
-	// 2018 day 3
-	prog = `
-=input lines | map (ints | struct ["id", "x", "y", "w", "h"])  ;;#123 @ 3,2: 5x4
-=makerect -: rectrel [_.id] _.x _.y _.w _.h
-=g map makerect | superimpose (concat)
-count (len > 1) g
-first (len == 1) g | head
-`
-
-	input, err := ioutil.ReadFile(os.Args[1])
+	if len(os.Args) != 3 {
+		log.Fatal("Usage: slouch <prog> <input>")
+	}
+	prog, err := readFile(os.Args[1])
 	if err != nil {
-		panic(err)
+		log.Fatalln("couldn't read program:", err)
+	}
+	input, err := readFile(os.Args[2])
+	if err != nil {
+		log.Fatalln("couldn't read input:", err)
 	}
 	p := parser.Parse(lexer.Tokenize(prog))
 	start := time.Now()
-	err = evaluator.New().Run(p, string(input), func(v evaluator.Value) { fmt.Println(v) })
+	err = evaluator.New().Run(p, input, func(v evaluator.Value) { fmt.Println(v) })
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -292,17 +292,13 @@ func (p *evalPreview) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 	return
 }
 
-func createCookieFile(cookie string) error {
-	return ioutil.WriteFile("cookie.txt", []byte(cookie), 0660)
-}
-
 func getCookieFromFile() string {
 	filename := "cookie.txt"
 	if _, err := os.Stat(filename); err != nil {
 		if err != nil {
 			log.Println("Cookie file not found! Please place your token into AOC_SESSION or cookie.txt")
 		}
-		if err := createCookieFile(""); err != nil {
+		if err := ioutil.WriteFile(filename, []byte(""), 0660); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "repl" {
 		log.SetFlags(0)
 
-		var input, solution, cookie string
+		var input, solution string
 		var day, year, part int
 		eval := evaluator.New()
 		prompt, err := readline.New("slouch> ")
@@ -142,16 +142,6 @@ func main() {
 				prev.input = input
 				eval = evaluator.New()
 				prev.eval = eval
-
-			case ":setcookie":
-				cookie = args[1]
-				if err := createCookieFile(cookie); err != nil {
-					log("Couldn't create cookie file:", err)
-					break
-				}
-				eval = evaluator.New()
-				prev.eval = eval
-				log("Cookie saved!")
 
 			case ":setday":
 				day, _ = strconv.Atoi(args[1])
@@ -310,7 +300,7 @@ func getCookieFromFile() string {
 	filename := "cookie.txt"
 	if _, err := os.Stat(filename); err != nil {
 		if err != nil {
-			log.Println("Cookie file not found! Please log into AoC or use :setcookie")
+			log.Println("Cookie file not found! Please place your token into AOC_SESSION or cookie.txt")
 		}
 		if err := createCookieFile(""); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Hello, I'm that guy you were talking to yesterday, I did some other changes to my cookie from file code, so if the system can't get the AoC cookie automatically with `os.Getenv("AOC_TOKEN")` when running `:setday`, it grabs from a file `cookie.txt` instead.
When using `:setday` and the cookie file doesn't exist, it creates an empty file to prevent reading errors (there may be a better way to do this though)
To use `:setcookie` the user needs to get the AoC cookie using the guide https://github.com/wimglenn/advent-of-code-wim/issues/1 and type `:setcookie <cookievalue>`, the <cookievalue> being everything between `session=` and the first `;` on that string:

`:setcookie 53616c2457214f5fd61f09acd05afad5e48ace27ae4917cfd0863c706cd508be236b52e3d2f4e2f90a252cb`
(not a real cookie, just an example)